### PR TITLE
Enabling `branch` option in pull command

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "lib"
   ],
   "jest": {
+    "testEnvironment": "node",
     "testRegex": "tests(/|/.*/)[^_/]*[jt]sx?$",
     "verbose": true
   },

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -8,14 +8,18 @@ export default class Pull extends Command {
   static examples = ['$ dotstow pull'];
 
   static flags = {
+    branch: flags.string({ char: 'b', required: false }),
     debug: flags.boolean({ char: 'd', required: false })
   };
 
   async run() {
     const { flags } = this.parse(Pull);
+
     const options: Options = {
-      debug: !!flags.debug
+      debug: !!flags.debug,
+      branch: flags.branch
     };
+
     return pull(options);
   }
 }

--- a/tests/commands/pull.ts
+++ b/tests/commands/pull.ts
@@ -1,0 +1,26 @@
+import Pull from '../../src/commands/pull';
+import pull from '../../src/actions/pull';
+
+jest.mock('../../src/actions/pull', () => jest.fn(() => 'PULL_RESPONSE'));
+
+describe('pull command', () => {
+  it('should call `pull` with default options', async () => {
+    const result = await Pull.run([]);
+
+    expect(pull).toHaveBeenCalledWith({ debug: false, branch: undefined });
+
+    expect(result).toBe('PULL_RESPONSE');
+  });
+
+  it('should call `pull` with debug enabled', async () => {
+    await Pull.run(['--debug']);
+
+    expect(pull).toHaveBeenCalledWith({ debug: true, branch: undefined });
+  });
+
+  it('should call `pull` with passed branch', async () => {
+    await Pull.run(['--branch=main']);
+
+    expect(pull).toHaveBeenCalledWith({ debug: false, branch: 'main' });
+  });
+});


### PR DESCRIPTION
This PR adds `branch` flag to the `pull` command

Related issue #14 

Changes,

- Set `jest.testEnvironment` to `node` – to fix timer related error
- enabled `branch` flag for `Pull` command
- Added tests for `Pull` command